### PR TITLE
Specs data validation fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/bin/3d-tiles-samples-generator.ts
+++ b/bin/3d-tiles-samples-generator.ts
@@ -1268,7 +1268,7 @@ function saveBatchedTileset(tilesetName, tileOptions, tilesetOptions?) {
         // old .b3dm
         var b3dm = result.b3dm;
         if (tilesetOptions.contentDataUri) {
-            var dataUri = dataUriParser.format('.b3dm', b3dm);
+            var dataUri = dataUriParser.format('.b3dm', b3dm).content;
             tilesetOptions.contentUri = dataUri;
             return saveJson(
                 tilesetPath,

--- a/lib/createB3dm.js
+++ b/lib/createB3dm.js
@@ -47,13 +47,16 @@ function createB3dm(options) {
 }
 
 function createB3dmCurrent(glb, featureTableJson, featureTableBinary, batchTableJson, batchTableBinary) {
+
+    const glbPadded = getBufferPadded(glb);
+
     const version = 1;
     const headerByteLength = 28;
     const featureTableJsonByteLength = featureTableJson.length;
     const featureTableBinaryByteLength = featureTableBinary.length;
     const batchTableJsonByteLength = batchTableJson.length;
     const batchTableBinaryByteLength = batchTableBinary.length;
-    const gltfByteLength = glb.length;
+    const gltfByteLength = glbPadded.length;
     const byteLength = headerByteLength + featureTableJsonByteLength + featureTableBinaryByteLength + batchTableJsonByteLength + batchTableBinaryByteLength + gltfByteLength;
 
     const header = Buffer.alloc(headerByteLength);
@@ -65,7 +68,7 @@ function createB3dmCurrent(glb, featureTableJson, featureTableBinary, batchTable
     header.writeUInt32LE(batchTableJsonByteLength, 20);
     header.writeUInt32LE(batchTableBinaryByteLength, 24);
 
-    return Buffer.concat([header, featureTableJson, featureTableBinary, batchTableJson, batchTableBinary, glb]);
+    return Buffer.concat([header, featureTableJson, featureTableBinary, batchTableJson, batchTableBinary, glbPadded]);
 }
 
 function createB3dmDeprecated1(glb, batchLength, batchTableJson) {

--- a/lib/createI3dm.js
+++ b/lib/createI3dm.js
@@ -30,12 +30,13 @@ function createI3dm(options) {
 
     const gltfFormat = defined(options.glb) ? 1 : 0;
     const gltfBuffer = defined(options.glb) ? options.glb : getGltfUriBuffer(options.uri);
+    const gltfBufferPadded = getBufferPadded(gltfBuffer);
 
     const featureTableJsonByteLength = featureTableJson.length;
     const featureTableBinaryByteLength = featureTableBinary.length;
     const batchTableJsonByteLength = batchTableJson.length;
     const batchTableBinaryByteLength = batchTableBinary.length;
-    const gltfByteLength = gltfBuffer.length;
+    const gltfByteLength = gltfBufferPadded.length;
     const byteLength = headerByteLength + featureTableJsonByteLength + featureTableBinaryByteLength + batchTableJsonByteLength + batchTableBinaryByteLength + gltfByteLength;
 
     const header = Buffer.alloc(headerByteLength);
@@ -48,7 +49,7 @@ function createI3dm(options) {
     header.writeUInt32LE(batchTableBinaryByteLength, 24);
     header.writeUInt32LE(gltfFormat, 28);
 
-    return Buffer.concat([header, featureTableJson, featureTableBinary, batchTableJson, batchTableBinary, gltfBuffer]);
+    return Buffer.concat([header, featureTableJson, featureTableBinary, batchTableJson, batchTableBinary, gltfBufferPadded]);
 }
 
 function getGltfUriBuffer(uri) {


### PR DESCRIPTION
Fixes that have been the result of running the validator against the data that was created with the samples generator:

- (Added `.gitignore`)
- Write a proper data URI for data URI content
- Adds a padding to the GLB content of B3DM and I3DM

Fixes https://github.com/CesiumGS/3d-tiles-samples-generator/issues/1 , probably...
