### PR TITLE
Pin bluebird types version to 3.5.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "simplex-noise": "^2.4.0"
   },
   "devDependencies": {
-    "@types/bluebird": "^3.5.32",
+    "@types/bluebird": "3.5.20",
     "@types/fs-extra": "^9.0.1",
     "@types/jasmine": "^3.5.11",
     "@types/jest": "^26.0.5",


### PR DESCRIPTION
Trying to `npm run build` a fresh clone caused errors similar to those in https://github.com/DefinitelyTyped/DefinitelyTyped/issues/27374 

This change pins the `@types/bluebird` version to `3.5.20` and should resolve the immediate issue. Further investigations of _what_ was wrong there, exactly, and what could be the best way to nestle the versions into a "compatible range" may be done later.
